### PR TITLE
Container timezone configurable with '-e TZ=...'. Fallback UTC.

### DIFF
--- a/1.2.0/Dockerfile
+++ b/1.2.0/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /tmp
 RUN bash -el /tmp/install.sh https://github.com/mdzio/ccu-historian/releases/download/1.2.0/ccu-historian-1.2.0-bin.zip
 
 ENV CONFIG_TYPE=CCU2
+ENV TZ=UTC
+
+RUN ln -nsf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 EXPOSE 80 2098 2099
 


### PR DESCRIPTION
Changed the Dockerfile to accept a new TZ parameter.
This parameter will be used to configure the container timezone. Fallback is UTC.
Additional optional parameter: e.g. "-e TZ=Europe/Berlin" will set the internal timezone to Berlin.


Reason for the change:
The internal timezone of a container is UTC. This causes the data points in CCU-Historian to have an time offset compared to the CCU timezone.